### PR TITLE
OEL-306: Provide default content feature.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "openeuropa/code-review": "^1.6",
         "openeuropa/drupal-core-require-dev": "^8.9 || ^9.1",
         "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "drupal/default_content": "^2.0@alpha",
         "phpspec/prophecy-phpunit": "^1 || ^2"
     },
     "scripts": {

--- a/modules/oe_showcase_default_content/README.md
+++ b/modules/oe_showcase_default_content/README.md
@@ -1,0 +1,3 @@
+# OpenEuropa Showcase default content
+
+Provide default content to oe_showcase pages

--- a/modules/oe_showcase_default_content/oe_showcase_default_content.info.yml
+++ b/modules/oe_showcase_default_content/oe_showcase_default_content.info.yml
@@ -1,0 +1,7 @@
+name: OpenEuropa Showcase default content
+type: module
+description: Provide default content to oe_showcase pages
+package: OpenEuropa
+core_version_requirement: ^8.9 || ^9.1
+dependencies:
+  - default_content:default_content

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -4,23 +4,24 @@ description: 'OpenEuropa Showcase installation profile.'
 core_version_requirement: ^8.9 || ^9.1
 
 dependencies:
-  - node
   - block
-  - config
-  - menu_link_content
-  - datetime
   - block_content
+  - config
+  - datetime
+  - dblog
+  - dynamic_page_cache
   - editor
+  - file
+  - filter
   - image
+  - menu_link_content
+  - node
+  - oe_showcase_default_content
   - options
   - path
   - page_cache
-  - dynamic_page_cache
-  - taxonomy
-  - dblog
   - toolbar
-  - file
-  - filter
+  - taxonomy
   - user
   - views
 

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -22,6 +22,7 @@ drupal:
     - "./vendor/bin/drush -y config-set system.performance css.preprocess 0"
     - "./vendor/bin/drush -y config-set system.performance js.preprocess 0"
     # Enable the modules.
+    - "./vendor/bin/drush en oe_showcase_default_content -y"
     - "./vendor/bin/drush en config_devel -y"
     - "./vendor/bin/drush cr"
   settings:


### PR DESCRIPTION
## OPENEUROPA-OEL-306

### Description

Added required features to allow to store default content for showcase library.

### Change log

- Added: oe_showcase_default_content submodule
- Changed:
- Deprecated:
- Removed: 
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```