### PR TITLE
OEL-1047: Update showcase to BCL-19.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "openeuropa/oe_media": "^1.14",
         "openeuropa/oe_multilingual": "^1.9",
         "openeuropa/oe_paragraphs": "dev-master",
-        "openeuropa/oe_whitelabel": "0.1.202202071145"
+        "openeuropa/oe_whitelabel": "0.1.202202080830"
     },
     "suggest": {
         "oomphinc/composer-installers-extender": "Required to use drupal/jquery_ui_touch_punch module.",
@@ -104,6 +104,14 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "./build"
+            }
+        },
+        "patches": {
+            "openeuropa/oe_bootstrap_theme": {
+                "latest 1.x": "https://github.com/openeuropa/oe_bootstrap_theme/compare/0.1.202202072010...1.x.patch"
+            },
+            "openeuropa/oe_whitelabel": {
+                "latest 1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202202080830...1.x.patch"
             }
         }
     },


### PR DESCRIPTION
## OPENEUROPA-1047

### Description

Update to BCL v.0.19.0

### Change log

- Added:
- Changed: composer to a dev relase and patches to manage the updates from oe_bootstrap_theme and oe_whitelabel
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

