### PR TITLE
OEL-1134: Add OE Contact forms honeypot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "drupal/facets": "^1.8.0",
         "drupal/facets_form": "1.x-dev",
         "drupal/file_link": "^2.0.6",
+        "drupal/honeypot": "^2.0",
         "drupal/search_api": "^1.21",
         "drupal/search_api_autocomplete": "^1.5",
         "easyrdf/easyrdf": "1.0.0 as 0.9.1",

--- a/modules/oe_showcase_contact_forms/tests/src/ExistingSite/IntegrationTest.php
+++ b/modules/oe_showcase_contact_forms/tests/src/ExistingSite/IntegrationTest.php
@@ -18,6 +18,10 @@ class IntegrationTest extends ShowcaseExistingSiteTestBase {
     $this->markEntityTypeForCleanup('node');
     $this->markEntityTypeForCleanup('paragraph');
 
+    // Disable the time limit to avoid honeypot error due to
+    // the quick submission form.
+    \Drupal::configFactory()->getEditable('honeypot.settings')->set('time_limit', 0)->save();
+
     $assert_session = $this->assertSession();
     $page = $this->getSession()->getPage();
 

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -37,7 +37,6 @@ install:
   - oe_showcase_page
   - oe_showcase_search
   - oe_showcase_contact_forms
-  - oe_showcase_contact_forms_honeypot
   - oe_whitelabel_helper
   - oe_whitelabel_search
   - options

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -37,6 +37,7 @@ install:
   - oe_showcase_page
   - oe_showcase_search
   - oe_showcase_contact_forms
+  - oe_showcase_contact_forms_honeypot
   - oe_whitelabel_helper
   - oe_whitelabel_search
   - options

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -8,6 +8,7 @@ install:
   - ckeditor
   - config
   - content_translation
+  - contact_forms_honeypot
   - datetime
   - dblog
   - default_content

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -8,7 +8,6 @@ install:
   - ckeditor
   - config
   - content_translation
-  - contact_forms_honeypot
   - datetime
   - dblog
   - default_content
@@ -26,6 +25,7 @@ install:
   - oe_bootstrap_theme_helper
   - oe_bootstrap_theme_paragraphs
   - oe_content:oe_content_timeline_field
+  - oe_contact_forms_honeypot
   - oe_corporate_blocks
   - oe_multilingual
   - oe_paragraphs


### PR DESCRIPTION
## OPENEUROPA-1134

### Description
Composer.json and showcase.info to enable contact form honeypot submodule.