### PR TITLE
OEL-1200: Use new version of oe_whitelabel.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,11 +114,6 @@
             "locations": {
                 "web-root": "./build"
             }
-        },
-        "patches": {
-            "openeuropa/oe_whitelabel": {
-                "latest 1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202202221259...1.x.diff"
-            }
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "openeuropa/oe_multilingual": "^1.9",
         "openeuropa/oe_paragraphs": "dev-master",
         "openeuropa/oe_starter_content": "1.x-dev",
-        "openeuropa/oe_whitelabel": "0.1.202202080830"
+        "openeuropa/oe_whitelabel": "0.1.202202221259"
     },
     "suggest": {
         "oomphinc/composer-installers-extender": "Required to use drupal/jquery_ui_touch_punch module.",
@@ -120,7 +120,7 @@
                 "latest 1.x": "https://github.com/openeuropa/oe_bootstrap_theme/compare/0.1.202202072010...1.x.patch"
             },
             "openeuropa/oe_whitelabel": {
-                "latest 1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202202080830...1.x.diff"
+                "latest 1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202202221259...1.x.diff"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -116,9 +116,6 @@
             }
         },
         "patches": {
-            "openeuropa/oe_bootstrap_theme": {
-                "latest 1.x": "https://github.com/openeuropa/oe_bootstrap_theme/compare/0.1.202202072010...1.x.patch"
-            },
             "openeuropa/oe_whitelabel": {
                 "latest 1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202202221259...1.x.diff"
             }


### PR DESCRIPTION
The previous version of oe_whitelabel caused failures in drone, because of a patch conflict in oe_whitelabel.info.yml:
The *.tar.gz added "# Information added by OpenEuropa packaging script", which conflicts with a change from the patch.