### PR TITLE
OEL-1238: Eliminate autoload from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,11 +72,6 @@
             "url": "https://github.com/openeuropa/oe_starter_content"
         }
     },
-    "autoload": {
-        "psr-4": {
-            "Drupal\\oe_showcase\\": "./src/"
-        }
-    },
     "autoload-dev": {
         "psr-4": {
             "Drupal\\Tests\\oe_showcase\\": "./tests/src/"


### PR DESCRIPTION
## OPENEUROPA-[OEL-1238](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1238)

### Description

Eliminate autoload pointing to src in composer.json.

### Change log

- Changed: composer.json

