### PR TITLE
OEL-1168: Configure multilingual feature

### DIFF
--- a/config/optional/block.block.showcase_pagetitle.yml
+++ b/config/optional/block.block.showcase_pagetitle.yml
@@ -9,7 +9,7 @@ dependencies:
 id: showcase_pagetitle
 theme: oe_whitelabel
 region: content
-weight: -5
+weight: -7
 provider: null
 plugin: page_title_block
 settings:

--- a/modules/oe_showcase_multilingual/config/optional/block.block.openeuropa_content_language_switcher.yml
+++ b/modules/oe_showcase_multilingual/config/optional/block.block.openeuropa_content_language_switcher.yml
@@ -15,7 +15,7 @@ plugin: oe_multilingual_content_language_switcher
 settings:
   id: oe_multilingual_content_language_switcher
   label: 'OpenEuropa Content Language Switcher'
-  label_display: visible
+  label_display: '0'
   provider: oe_multilingual
 visibility:
   'entity_bundle:node':
@@ -24,6 +24,7 @@ visibility:
     context_mapping:
       node: '@node.node_route_context:node'
     bundles:
+      oe_event: oe_event
       oe_news: oe_news
       oe_showcase_page: oe_showcase_page
       oe_showcase_search_demo: oe_showcase_search_demo

--- a/modules/oe_showcase_multilingual/config/optional/block.block.openeuropa_content_language_switcher.yml
+++ b/modules/oe_showcase_multilingual/config/optional/block.block.openeuropa_content_language_switcher.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - oe_multilingual
+  theme:
+    - oe_whitelabel
+id: openeuropa_content_language_switcher
+theme: oe_whitelabel
+region: content
+weight: -6
+provider: null
+plugin: oe_multilingual_content_language_switcher
+settings:
+  id: oe_multilingual_content_language_switcher
+  label: 'OpenEuropa Content Language Switcher'
+  label_display: visible
+  provider: oe_multilingual
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      oe_news: oe_news
+      oe_showcase_page: oe_showcase_page
+      oe_showcase_search_demo: oe_showcase_search_demo

--- a/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
+++ b/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
@@ -5,6 +5,7 @@ core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 
 dependencies:
+  - drupal:config_translation
   - openeuropa:oe_multilingual
 
 config_devel:

--- a/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
+++ b/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Multilingual
 type: module
 description: OpenEuropa Showcase Multilingual.
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 
 dependencies:

--- a/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
+++ b/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
@@ -9,4 +9,4 @@ dependencies:
 
 config_devel:
   optional:
-    - block.block.openeuropa_content_language_switcher:
+    - block.block.openeuropa_content_language_switcher

--- a/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
+++ b/modules/oe_showcase_multilingual/oe_showcase_multilingual.info.yml
@@ -1,0 +1,12 @@
+name: OpenEuropa Showcase Multilingual
+type: module
+description: OpenEuropa Showcase Multilingual.
+core_version_requirement: ^8.9 || ^9.1
+package: OpenEuropa Showcase
+
+dependencies:
+  - openeuropa:oe_multilingual
+
+config_devel:
+  optional:
+    - block.block.openeuropa_content_language_switcher:

--- a/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
+++ b/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
@@ -54,8 +54,7 @@ class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
     $node->save();
     $this->drupalGet($node->toUrl());
     $this->clickLink('English');
-    $this->getSession()->wait(10000);
-    $modal = $page->find('xpath', '//div[@id=\'languageModal\']');
+    $modal = $assert_session->waitForElementVisible('xpath', '//div[@id=\'languageModal\']');
     $this->assertTrue($modal->isVisible());
     $this->clickLink('português');
     $assert_session->pageTextContains('Translated to PT');

--- a/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
+++ b/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
@@ -41,17 +41,15 @@ class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
       'status' => 1,
     ];
     $node = $this->createNode($values);
-
-    // Go to the translation page, assert the enabled languages are present.
     $this->drupalGet('/node/' . $node->id() . '/translations');
-    $rows = $page->findAll('css', 'table tbody tr');
+
     // Assert all 24 EU languages are available.
+    $rows = $page->findAll('css', 'table tbody tr');
     $this->assertCount(24, $rows);
-    $this->assertSession()->linkNotExists('Translate locally');
-    // Assert translations can be added to each language.
+    $assert_session->linkNotExists('Translate locally');
     $this->assertCount(23, $page->findAll('xpath', '//a[text()=\'Add\']'));
 
-    // Add a translation and assert that the values are present.
+    // Add a translation.
     $node->addTranslation('pt-pt', ['title' => 'Translated to PT'] + $node->toArray());
     $node->save();
     $this->drupalGet($node->toUrl());
@@ -66,18 +64,19 @@ class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
     $modal = $page->find('xpath', '//div[@id=\'languageModal\']');
     $this->assertFalse($modal->isVisible());
 
-    // Change the interface language to an untranslated item
-    // to show the language switcher block.
+    // Show the language switcher block by selecting an untranslated language.
     $this->clickLink('português');
     $this->getSession()->wait(10000);
     $this->clickLink('français');
-    $language_switcher_block = $page->find('xpath', '//div[@id="block-openeuropa-content-language-switcher"]');
+    $language_switcher_block = $page->find(
+      'xpath',
+      '//div[@id="block-openeuropa-content-language-switcher"]'
+    );
     $this->assertTrue($language_switcher_block->isVisible());
 
-    // Click on one language to assert the correct values are in the page.
+    // Assert a valid translation is available.
     $language_switcher_block->findLink('português')->click();
     $assert_session->pageTextContains('Translated to PT');
-
   }
 
 }

--- a/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
+++ b/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_showcase_multilingual\ExistingSiteJavascript;
+
+use Drupal\Tests\oe_showcase\ExistingSiteJavascript\ShowcaseExistingSiteJavascriptTestBase;
+
+/**
+ * Tests oe_showcase_multilingual translation is available.
+ */
+class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
+
+  /**
+   * Create a page node and test language switcher block.
+   */
+  public function testOeMultilingualTranslation(): void {
+    // Mark test content for deletion after the test has finished.
+    $this->markEntityTypeForCleanup('node');
+
+    $assert_session = $this->assertSession();
+    $page = $this->getSession()->getPage();
+
+    $this->drupalLogin($this->createUser([
+      'create oe_showcase_page content',
+      'delete any oe_showcase_page content',
+      'delete own oe_showcase_page content',
+      'edit own oe_showcase_page content',
+      'translate oe_showcase_page node',
+      'administer content translation',
+      'create content translations',
+      'delete content translations',
+      'update content translations',
+    ]));
+
+    // Create a node and assert we can see all languages in the list but
+    // no operations.
+    $values = [
+      'type' => 'oe_showcase_page',
+      'title' => 'Test page',
+      'status' => 1,
+    ];
+    $node = $this->createNode($values);
+
+    // Go to the translation page, assert the enabled languages are present.
+    $this->drupalGet('/node/' . $node->id() . '/translations');
+    $rows = $page->findAll('css', 'table tbody tr');
+    // Assert all 24 EU languages are available.
+    $this->assertCount(24, $rows);
+    $this->assertSession()->linkNotExists('Translate locally');
+    // Assert translations can be added to each language.
+    $this->assertCount(23, $page->findAll('xpath', '//a[text()=\'Add\']'));
+
+    // Add a translation and assert that the values are present.
+    $node->addTranslation('pt-pt', ['title' => 'Translated to PT'] + $node->toArray());
+    $node->save();
+    $this->drupalGet($node->toUrl());
+    $this->clickLink('English');
+    $this->getSession()->wait(10000);
+    $modal = $page->find('xpath', '//div[@id=\'languageModal\']');
+    $this->assertTrue($modal->isVisible());
+    $this->clickLink('português');
+    $assert_session->pageTextContains('Translated to PT');
+
+    // Assert the language interface block is hidden.
+    $modal = $page->find('xpath', '//div[@id=\'languageModal\']');
+    $this->assertFalse($modal->isVisible());
+
+    // Change the interface language to an untranslated item
+    // to show the language switcher block.
+    $this->clickLink('português');
+    $this->getSession()->wait(10000);
+    $this->clickLink('français');
+    $language_switcher_block = $page->find('xpath', '//div[@id="block-openeuropa-content-language-switcher"]');
+    $this->assertTrue($language_switcher_block->isVisible());
+
+    // Click on one language to assert the correct values are in the page.
+    $language_switcher_block->findLink('português')->click();
+    $assert_session->pageTextContains('Translated to PT');
+
+  }
+
+}

--- a/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
+++ b/modules/oe_showcase_multilingual/tests/src/ExistingSiteJavascript/MultilingualTest.php
@@ -12,7 +12,7 @@ use Drupal\Tests\oe_showcase\ExistingSiteJavascript\ShowcaseExistingSiteJavascri
 class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
 
   /**
-   * Create a page node and test language switcher block.
+   * Test node translation.
    */
   public function testOeMultilingualTranslation(): void {
     // Mark test content for deletion after the test has finished.
@@ -66,7 +66,7 @@ class MultilingualTest extends ShowcaseExistingSiteJavascriptTestBase {
 
     // Show the language switcher block by selecting an untranslated language.
     $this->clickLink('português');
-    $this->getSession()->wait(10000);
+    $this->assertSession()->waitForElementVisible('css', '#languageModal');
     $this->clickLink('français');
     $language_switcher_block = $page->find(
       'xpath',

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -67,25 +67,13 @@ themes:
 
 config_devel:
   install:
-    - block.block.breadcrumbs
-    - block.block.corporateeulogoblock
-    - block.block.eufooterblock
-    - block.block.euloginlinkblock
-    - block.block.languageswitcherinterfacetext
-    - block.block.mainnavigation
-    - block.block.pagetitle
-    - block.block.showcase_exposed_sort_form
-    - block.block.showcase_facets_form
-    - block.block.showcase_facets_summary
-    - block.block.sitebranding
-    - block.block.whitelabelsearchblock
     - easy_breadcrumb.settings
     - editor.editor.full_html
     - editor.editor.rich_text
-    - field.field.node.oe_news.body
-    - field.field.node.oe_news.oe_summary
     - field.field.node.oe_event.body
     - field.field.node.oe_event.oe_summary
+    - field.field.node.oe_news.body
+    - field.field.node.oe_news.oe_summary
     - filter.format.full_html
     - filter.format.rich_text
     - filter.format.simple_rich_text
@@ -97,3 +85,17 @@ config_devel:
     - user.role.anonymous
     - user.role.authenticated
     - user.role.editor
+  optional:
+    - block.block.seven_breadcrumbs
+    - block.block.seven_content
+    - block.block.seven_help
+    - block.block.seven_local_actions
+    - block.block.seven_messages
+    - block.block.seven_page_title
+    - block.block.seven_primary_local_tasks
+    - block.block.seven_secondary_local_tasks
+    - block.block.showcase_exposed_sort_form
+    - block.block.showcase_facets_form
+    - block.block.showcase_facets_summary
+    - block.block.showcase_navigation
+    - block.block.showcase_pagetitle

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -38,6 +38,7 @@ install:
   - oe_paragraphs_social_feed
   - oe_paragraphs_timeline
   - oe_showcase_default_content
+  - oe_showcase_multilingual
   - oe_showcase_navigation
   - oe_showcase_page
   - oe_showcase_search


### PR DESCRIPTION
## OPENEUROPA-[OEL-1168]

### Description

- Create oe_showcase_multilingual.
- Place and export configuration for the Language switcher block.
- Enabled oe_showcase_multilingual on oe_showcase.info.
- Create tests.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

