### PR TITLE
OEL-1157: Switch to Drupal 9.2 / Composer 2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,7 @@ services:
     image: registry.fpfis.eu/fpfis/httpd-php:${PHP_VERSION}-ci
     environment:
       - DOCUMENT_ROOT=/test/oe_showcase
+      - COMPOSERVER=--2
   mysql:
     image: registry.fpfis.eu/fpfis/sql:percona-5.7
     command: --innodb-log-file-size=1G --max_allowed_packet=1G --innodb-buffer-pool-size=512M --wait_timeout=3000 --net_write_timeout=3000 --log_error_verbosity=3

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,6 @@ pipeline:
     volumes:
       - /cache:/cache
     commands:
-      - composer self-update --2
       - composer install --ansi --no-progress
 
   site-install:

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,12 +47,13 @@ pipeline:
     volumes:
       - /cache:/cache
     commands:
-      - composer self-update --1
-      - composer install --ansi --no-suggest --no-progress
+      - composer self-update --2
+      - composer install --ansi --no-progress
 
   site-install:
     image: registry.fpfis.eu/fpfis/httpd-php:${PHP_VERSION}-ci
     commands:
+      - while ! mysqladmin ping -h mysql --silent; do sleep 1; done
       - ./vendor/bin/run drupal:site-install
     when:
       event:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "easyrdf/easyrdf": "1.0.0 as 0.9.1",
         "npm-asset/jquery-ui-touch-punch": "^0.2.3",
         "oomphinc/composer-installers-extender": "^2.0",
-        "openeuropa/composer-artifacts": "^0.1",
+        "openeuropa/composer-artifacts": "^1.0.0-alpha1",
         "openeuropa/oe_authentication": "^1.5",
         "openeuropa/oe_contact_forms": "dev-master",
         "openeuropa/oe_content": "^2.6.0",
@@ -46,7 +46,7 @@
         "drupal/core-dev": "^9.2",
         "drush/drush": "~10.3",
         "openeuropa/code-review": "^1.6 || ^2.0",
-        "openeuropa/task-runner-drupal-project-symlink": "^1.0",
+        "openeuropa/task-runner-drupal-project-symlink": "^1.0-beta5",
         "phpspec/prophecy-phpunit": "^1 || ^2",
         "weitzman/drupal-test-traits": "^1.5"
     },
@@ -94,14 +94,14 @@
         "artifacts": {
             "openeuropa/oe_bootstrap_theme": {
                 "dist": {
-                    "url": "https://github.com/{name}/releases/download/{pretty-version}/{project-name}-{pretty-version}.tar.gz",
-                    "type": "tar"
+                    "url": "https://github.com/{name}/releases/download/{pretty-version}/{project-name}-{pretty-version}.zip",
+                    "type": "zip"
                 }
             },
             "openeuropa/oe_whitelabel": {
                 "dist": {
-                    "url": "https://github.com/{name}/releases/download/{pretty-version}/{project-name}-{pretty-version}.tar.gz",
-                    "type": "tar"
+                    "url": "https://github.com/{name}/releases/download/{pretty-version}/{project-name}-{pretty-version}.zip",
+                    "type": "zip"
                 }
             }
         },
@@ -123,6 +123,15 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "openeuropa/composer-artifacts": true,
+            "composer/installers": true,
+            "drupal/core-composer-scaffold": true,
+            "cweagans/composer-patches": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpro/grumphp": true,
+            "oomphinc/composer-installers-extender": true
+        }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - .:/var/www/html # Non Mac users.
       # - nfsmount:/var/www/html # Mac Users with the nfsmount volume.
     environment:
+      COMPOSERVER: "--2"
       XDEBUG_CONFIG: "client_host=172.17.0.1" # Non-Mac users.
       # XDEBUG_CONFIG: "client_host=host.docker.internal" # Mac users.
       XDEBUG_MODE: "develop, debug"

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -12,3 +12,23 @@ parameters:
     - php
     - theme
     - yml
+
+  extra_tasks:
+    phpparser:
+      ignore_patterns:
+       - vendor/
+       - build/
+      visitors:
+        declare_strict_types: ~
+      triggered_by:
+        - php
+        - module
+        - inc
+        - theme
+        - install
+
+grumphp:
+  git_hook_variables:
+    EXEC_GRUMPHP_COMMAND: 'docker-compose exec -T web'
+  extensions:
+    - OpenEuropa\CodeReview\ExtraTasksExtension

--- a/modules/oe_showcase_contact_forms/oe_showcase_contact_forms.info.yml
+++ b/modules/oe_showcase_contact_forms/oe_showcase_contact_forms.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Contact form
 type: module
 description: Provides a demo for the contact form feature.
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 dependencies:
   - block_field:block_field

--- a/modules/oe_showcase_default_content/oe_showcase_default_content.info.yml
+++ b/modules/oe_showcase_default_content/oe_showcase_default_content.info.yml
@@ -2,7 +2,7 @@ name: OpenEuropa Showcase Default Content
 type: module
 description: Provide default content for showcasing.
 package: OpenEuropa Showcase
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 dependencies:
   - default_content:default_content
   - drupal:content_translation

--- a/modules/oe_showcase_navigation/oe_showcase_navigation.info.yml
+++ b/modules/oe_showcase_navigation/oe_showcase_navigation.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Navigation
 type: module
 description: Demo navigation feature based on oe_whitelabel theme and easybreadcrumbs.
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 dependencies:
   - drupal:views

--- a/modules/oe_showcase_page/oe_showcase_page.info.yml
+++ b/modules/oe_showcase_page/oe_showcase_page.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Page
 type: module
 description: Provides a demo page content type.
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 dependencies:
   - drupal:ckeditor

--- a/modules/oe_showcase_search/oe_showcase_search.info.yml
+++ b/modules/oe_showcase_search/oe_showcase_search.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Search
 type: module
 description: Provides a demo search content type and search functionality based on search_api.
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 package: OpenEuropa Showcase
 dependencies:
   - drupal:views

--- a/modules/oe_showcase_search/oe_showcase_search.module
+++ b/modules/oe_showcase_search/oe_showcase_search.module
@@ -5,6 +5,8 @@
  * Showcase search module.
  */
 
+declare(strict_types =  1);
+
 /**
  * Implements hook_theme().
  */

--- a/oe_showcase.info.yml
+++ b/oe_showcase.info.yml
@@ -1,7 +1,7 @@
 name: OpenEuropa Showcase Profile
 type: profile
 description: 'Install with commonly used features for OpenEuropa Showcase profile.'
-core_version_requirement: ^8.9 || ^9.1
+core_version_requirement: ^9.2
 
 install:
   - block


### PR DESCRIPTION
## OEL-1157

### Description

Update the following files to use composer 2:
.drone.yml
docker-compose.yml
grump.yml.dist
and dependencies on composer.json.
Note that the oe_showcase_search.module file was also updated on this ticket. Please refer to ticket for more info.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

