### PR TITLE
OEL-1284: Override whitelabel search form block to enable autocomplete.

### DIFF
--- a/config/optional/block.block.oe_whitelabel_search_form.yml
+++ b/config/optional/block.block.oe_whitelabel_search_form.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - oe_whitelabel_search
+  theme:
+    - oe_whitelabel
+id: oe_whitelabel_search_form
+theme: oe_whitelabel
+region: header_right
+weight: 0
+provider: null
+plugin: whitelabel_search_block
+settings:
+  id: whitelabel_search_block
+  label: 'Whitelabel Search Block'
+  label_display: '0'
+  provider: oe_whitelabel_search
+  form:
+    action: '#'
+  input:
+    name: text
+    label: Search
+    classes: ''
+    placeholder: Search
+  button:
+    classes: ''
+  view_options:
+    enable_autocomplete: true
+    id: showcase_search
+    display: showcase_search_page
+visibility: {  }

--- a/config/optional/block.block.oe_whitelabel_search_form.yml
+++ b/config/optional/block.block.oe_whitelabel_search_form.yml
@@ -17,14 +17,14 @@ settings:
   label_display: '0'
   provider: oe_whitelabel_search
   form:
-    action: '#'
+    action: 'search'
   input:
-    name: text
+    name: search_api_fulltext
     label: Search
-    classes: ''
+    classes: null
     placeholder: Search
   button:
-    classes: ''
+    classes: null
   view_options:
     enable_autocomplete: true
     id: showcase_search


### PR DESCRIPTION
## OPENEUROPA-OEL-1284
### Description

Override whitelabel search form block to enable autocomplete.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

