### PR TITLE
OEL-1288: Fix text formatter missing paragraph tag.

### DIFF
--- a/config/install/filter.format.rich_text.yml
+++ b/config/install/filter.format.rich_text.yml
@@ -11,6 +11,6 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid>'
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <img src alt data-entity-type data-entity-uuid> <p>'
       filter_html_help: true
       filter_html_nofollow: false


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Fix missing paragraph tag on Rich text formatter.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

