### PR TITLE
OEL-1282: Upgrade oe_whitelabel version to alpha5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,6 @@
     "repositories": [
         {
             "type": "git",
-            "url": "https://github.com/openeuropa/oe_whitelabel"
-        },
-        {
-            "type": "git",
             "url": "https://github.com/openeuropa/oe_starter_content"
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -33,16 +33,16 @@
         "oomphinc/composer-installers-extender": "^2.0",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
         "openeuropa/oe_authentication": "^1.5",
-        "openeuropa/oe_contact_forms": "dev-master",
+        "openeuropa/oe_contact_forms": "^1.3",
         "openeuropa/oe_content": "^2.8.0",
         "openeuropa/oe_corporate_blocks": "^4.4",
         "openeuropa/oe_corporate_countries": "^2.0.0-alpha3",
         "openeuropa/oe_media": "^1.14",
         "openeuropa/oe_multilingual": "^1.9",
-        "openeuropa/oe_paragraphs": "dev-master",
+        "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/oe_starter_content": "1.x-dev",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "0.1.202203081055"
+        "openeuropa/oe_whitelabel": "^1.0.0-alpha5"
     },
     "require-dev": {
         "composer/installers": "~1.11",


### PR DESCRIPTION
## OPENEUROPA-[OEL-1082](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1282)

### Description

Upgrade oe_contact_forms (^1.3).
Upgrade oe_paragraphs (^1.12).
Upgrade oe_whitelabel (^1.0.0-alpha5).