### PR TITLE
OEL-1307: Upgrade BCL to v0.20.0 on oe_showcase.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/oe_starter_content": "1.x-dev",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "0.1307.202203211515"
+        "openeuropa/oe_whitelabel": "0.1307.202203281920"
     },
     "require-dev": {
         "composer/installers": "~1.11",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/oe_starter_content": "1.x-dev",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "0.1307.202203281920"
+        "openeuropa/oe_whitelabel": "0.1.202203291000"
     },
     "require-dev": {
         "composer/installers": "~1.11",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/oe_starter_content": "1.x-dev",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "0.1307.202203181550"
+        "openeuropa/oe_whitelabel": "0.1307.202203211515"
     },
     "require-dev": {
         "composer/installers": "~1.11",

--- a/composer.json
+++ b/composer.json
@@ -92,9 +92,6 @@
         "patches": {
             "drupal/paragraphs": {
                 "https://www.drupal.org/project/paragraphs/issues/2890086": "https://www.drupal.org/files/issues/2021-12-23/respect-display-on-validation-2890086-55.patch"
-            },
-            "openeuropa/oe_bootstrap_theme" : {
-                "1.x latest": "https://github.com/openeuropa/oe_bootstrap_theme/compare/1.0.0-alpha7..1.x.diff"
             }
         },
         "artifacts": {

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "openeuropa/oe_paragraphs": "^1.12",
         "openeuropa/oe_starter_content": "1.x-dev",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "0.1.202203211838"
+        "openeuropa/oe_whitelabel": "0.1307.202203181550"
     },
     "require-dev": {
         "composer/installers": "~1.11",


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed: BCL version to 0.20.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

