### PR TITLE
OEL-759: Add facts and figure and description list paragraphs to the example page.

### DIFF
--- a/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
+++ b/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
@@ -284,6 +284,9 @@ default:
           behavior_settings:
             -
               value: {  }
+          oe_paragraphs_variant:
+            -
+              value: default
           content_translation_source:
             -
               value: und
@@ -568,9 +571,6 @@ default:
           behavior_settings:
             -
               value: {  }
-          revision_translation_affected:
-            -
-              value: true
           content_translation_source:
             -
               value: und
@@ -724,9 +724,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   content_translation_source:
                     -
                       value: und
@@ -763,9 +760,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   content_translation_source:
                     -
                       value: und
@@ -802,9 +796,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   content_translation_source:
                     -
                       value: und
@@ -841,9 +832,6 @@ default:
                   behavior_settings:
                     -
                       value: {  }
-                  revision_translation_affected:
-                    -
-                      value: true
                   content_translation_source:
                     -
                       value: und
@@ -868,3 +856,54 @@ default:
           oe_bt_n_columns:
             -
               value: 3
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 5633664f-2c3d-421c-89d1-147e1becb398
+          bundle: oe_description_list
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1648457626
+          behavior_settings:
+            -
+              value: {  }
+          content_translation_source:
+            -
+              value: und
+          content_translation_outdated:
+            -
+              value: false
+          field_oe_description_list_items:
+            -
+              term: Name
+              description: 'Rowan Leuthar'
+              format: plain_text
+            -
+              term: E-mail
+              description: test@domain.tld
+              format: plain_text
+            -
+              term: 'Phone number'
+              description: '+34 999 888 777'
+              format: plain_text
+            -
+              term: City
+              description: Brussels
+              format: plain_text
+            -
+              term: Message
+              description: 'Sed in libero ut nibh placerat accumsan. Vivamus quis mi. Sed lectus. Nullam tincidunt adipiscing enim. Nam eget dui.'
+              format: plain_text
+          field_oe_title:
+            -
+              value: 'Description List example'
+          oe_bt_orientation:
+            -
+              value: horizontal

--- a/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
+++ b/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
@@ -601,3 +601,270 @@ default:
           field_oe_timeline_expand:
             -
               value: 3
+    -
+      entity:
+        _meta:
+          version: '1.0'
+          entity_type: paragraph
+          uuid: 54585907-2af0-4d16-b83f-385b4036d6e8
+          bundle: oe_facts_figures
+          default_langcode: en
+        default:
+          status:
+            -
+              value: true
+          created:
+            -
+              value: 1647944528
+          behavior_settings:
+            -
+              value: {  }
+          revision_translation_affected:
+            -
+              value: true
+          content_translation_source:
+            -
+              value: und
+          content_translation_outdated:
+            -
+              value: false
+          field_oe_link:
+            -
+              uri: 'route:<nolink>'
+              title: 'Read more'
+              options: {  }
+          field_oe_paragraphs:
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: a1075f34-263a-4e09-8104-c8876481e979
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944528
+                  behavior_settings:
+                    -
+                      value: {  }
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: download
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Nunc condimentum sapien ut nibh finibus suscipit vitae at justo. Morbi quis odio faucibus, commodo tortor id, elementum libero.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Jira Tickets'
+                  field_oe_title:
+                    -
+                      value: '1529 JIRA Ticket'
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: 8b5e78f4-f85a-4cef-a94d-018c3437c625
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944751
+                  behavior_settings:
+                    -
+                      value: {  }
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: search
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Turpis varius congue venenatis, erat dui feugiat felis.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Feature tickets'
+                  field_oe_title:
+                    -
+                      value: '337 Features'
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: a7ec6e5d-5a41-4320-9e08-2c717186c822
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944788
+                  behavior_settings:
+                    -
+                      value: {  }
+                  revision_translation_affected:
+                    -
+                      value: true
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: facebook
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Cras vestibulum efficitur mi, quis porta tellus rutrum ut. Quisque at pulvinar sem.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Test tickets'
+                  field_oe_title:
+                    -
+                      value: '107 Tests'
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: 271e0d1e-b531-465a-b454-15ac602d699f
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944826
+                  behavior_settings:
+                    -
+                      value: {  }
+                  revision_translation_affected:
+                    -
+                      value: true
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: linkedin
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Aliquam lacinia diam eu sem malesuada, in interdum ante bibendum.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Test variants'
+                  field_oe_title:
+                    -
+                      value: '5670 Variants'
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: 350de078-cd54-4857-9114-c83c1ab971d7
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944855
+                  behavior_settings:
+                    -
+                      value: {  }
+                  revision_translation_affected:
+                    -
+                      value: true
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: twitter
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis nec lectus tortor.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Jira ticket'
+                  field_oe_title:
+                    -
+                      value: '345 Dev Ticket'
+            -
+              entity:
+                _meta:
+                  version: '1.0'
+                  entity_type: paragraph
+                  uuid: c26ace8b-a79b-496f-8e6e-66127750a12d
+                  bundle: oe_fact
+                  default_langcode: en
+                default:
+                  status:
+                    -
+                      value: true
+                  created:
+                    -
+                      value: 1647944931
+                  behavior_settings:
+                    -
+                      value: {  }
+                  revision_translation_affected:
+                    -
+                      value: true
+                  content_translation_source:
+                    -
+                      value: und
+                  content_translation_outdated:
+                    -
+                      value: false
+                  field_oe_icon:
+                    -
+                      value: camera
+                  field_oe_plain_text_long:
+                    -
+                      value: 'Sed efficitur bibendum rutrum. Nunc feugiat congue augue ac consectetur.'
+                  field_oe_subtitle:
+                    -
+                      value: 'Figma components'
+                  field_oe_title:
+                    -
+                      value: '43 Components'
+          field_oe_title:
+            -
+              value: 'Fact and figures'
+          oe_bt_n_columns:
+            -
+              value: 3

--- a/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
+++ b/modules/oe_showcase_default_content/content/node/a170562d-55f5-48b5-9e11-7a61d7677873.yml
@@ -853,7 +853,7 @@ default:
           field_oe_title:
             -
               value: 'Fact and figures'
-          oe_bt_n_columns:
+          oe_w_n_columns:
             -
               value: 3
     -
@@ -904,6 +904,6 @@ default:
           field_oe_title:
             -
               value: 'Description List example'
-          oe_bt_orientation:
+          oe_w_orientation:
             -
               value: horizontal

--- a/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
+++ b/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
@@ -43,7 +43,6 @@ settings:
       oe_description_list: oe_description_list
       oe_facts_figures: oe_facts_figures
       oe_links_block: oe_links_block
-      oe_list_item: oe_list_item
       oe_list_item_block: oe_list_item_block
       oe_map: oe_map
       oe_quote: oe_quote

--- a/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
+++ b/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
@@ -9,6 +9,8 @@ dependencies:
     - paragraphs.paragraphs_type.oe_banner
     - paragraphs.paragraphs_type.oe_chart
     - paragraphs.paragraphs_type.oe_content_row
+    - paragraphs.paragraphs_type.oe_description_list
+    - paragraphs.paragraphs_type.oe_facts_figures
     - paragraphs.paragraphs_type.oe_links_block
     - paragraphs.paragraphs_type.oe_list_item_block
     - paragraphs.paragraphs_type.oe_map
@@ -38,7 +40,10 @@ settings:
       oe_chart: oe_chart
       contact_form: contact_form
       oe_content_row: oe_content_row
+      oe_description_list: oe_description_list
+      oe_facts_figures: oe_facts_figures
       oe_links_block: oe_links_block
+      oe_list_item: oe_list_item
       oe_list_item_block: oe_list_item_block
       oe_map: oe_map
       oe_quote: oe_quote
@@ -71,7 +76,7 @@ settings:
         enabled: false
       oe_description_list:
         weight: 23
-        enabled: false
+        enabled: true
       oe_document:
         weight: 24
         enabled: false
@@ -80,7 +85,7 @@ settings:
         enabled: false
       oe_facts_figures:
         weight: 26
-        enabled: false
+        enabled: true
       oe_links_block:
         weight: 27
         enabled: true

--- a/modules/oe_showcase_page/oe_showcase_page.info.yml
+++ b/modules/oe_showcase_page/oe_showcase_page.info.yml
@@ -11,12 +11,14 @@ dependencies:
   - drupal:pathauto
   - oe_paragraphs:oe_paragraphs_banner
   - oe_paragraphs:oe_paragraphs_chart
+  - oe_paragraphs:oe_paragraphs_description_list
   - oe_paragraphs:oe_paragraphs_document
   - oe_paragraphs:oe_paragraphs_map
   - oe_paragraphs:oe_paragraphs_media
   - oe_paragraphs:oe_paragraphs_social_feed
   - oe_paragraphs:oe_paragraphs_timeline
   - openeuropa:oe_webtools
+  - openeuropa:oe_bootstrap_theme_paragraphs
 
 config_devel:
   install:

--- a/modules/oe_showcase_page/oe_showcase_page.info.yml
+++ b/modules/oe_showcase_page/oe_showcase_page.info.yml
@@ -18,7 +18,7 @@ dependencies:
   - oe_paragraphs:oe_paragraphs_social_feed
   - oe_paragraphs:oe_paragraphs_timeline
   - openeuropa:oe_webtools
-  - openeuropa:oe_bootstrap_theme_paragraphs
+  - openeuropa:oe_whitelabel_paragraphs
 
 config_devel:
   install:

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -245,6 +245,35 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'Fact 3 description'
     );
 
+    // Add Description list paragraph.
+    $page->pressButton('Add Description list');
+    $page->selectFieldOption(
+      'field_body[6][subform][oe_bt_orientation]',
+      'horizontal'
+    );
+    $page->fillField(
+      'field_body[6][subform][field_oe_title][0][value]',
+      'Example Description list'
+    );
+    $page->fillField(
+      'field_body[6][subform][field_oe_description_list_items][0][term]',
+      'First term'
+    );
+    $page->fillField(
+      'field_body[6][subform][field_oe_description_list_items][0][description][value]',
+      'First term description'
+    );
+
+    $page->pressButton('field_body_6_subform_field_oe_description_list_items_add_more');
+    $page->fillField(
+      'field_body[6][subform][field_oe_description_list_items][1][term]',
+      'Second term'
+    );
+    $page->fillField(
+      'field_body[6][subform][field_oe_description_list_items][1][description][value]',
+      'Second term description'
+    );
+
     // Save node.
     $page->pressButton('Save');
 
@@ -296,6 +325,13 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     $assert_session->pageTextContains('Fact 3 title');
     $assert_session->pageTextContains('Fact 3 subtitle');
     $assert_session->pageTextContains('Fact 3 description');
+
+    // Assert Description list.
+    $assert_session->pageTextContains('Example Description list');
+    $assert_session->pageTextContains('First term');
+    $assert_session->pageTextContains('First term description');
+    $assert_session->pageTextContains('Second term');
+    $assert_session->pageTextContains('Second term description');
   }
 
   /**

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -52,6 +52,8 @@ class PageTest extends ShowcaseExistingSiteTestBase {
         'Add Chart',
         'Add Contact form',
         'Add Content row',
+        'Add Description list',
+        'Add Facts and figures',
         'Add Links block',
         'Add Listing item block',
         'Add Map',
@@ -175,6 +177,74 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'Text description for rich text 1'
     );
 
+    // Add Facts and figures paragraph.
+    $page->pressButton('Add Facts and figures');
+    $page->fillField(
+      'field_body[5][subform][field_oe_title][0][value]',
+      'Example Facts and Figures'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_link][0][uri]',
+      'http://read.more'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_link][0][title]',
+      'Read more'
+    );
+
+    $page->selectFieldOption(
+      'field_body[5][subform][field_oe_paragraphs][0][subform][field_oe_icon]',
+      'download'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][0][subform][field_oe_title][0][value]',
+      'Fact 1 title'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][0][subform][field_oe_subtitle][0][value]',
+      'Fact 1 subtitle'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][0][subform][field_oe_plain_text_long][0][value]',
+      'Fact 1 description'
+    );
+
+    $page->pressButton('Add Fact');
+    $page->selectFieldOption(
+      'field_body[5][subform][field_oe_paragraphs][1][subform][field_oe_icon]',
+      'arrow-up'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][1][subform][field_oe_title][0][value]',
+      'Fact 2 title'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][1][subform][field_oe_subtitle][0][value]',
+      'Fact 2 subtitle'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][1][subform][field_oe_plain_text_long][0][value]',
+      'Fact 2 description'
+    );
+
+    $page->pressButton('Add Fact');
+    $page->selectFieldOption(
+     'field_body[5][subform][field_oe_paragraphs][2][subform][field_oe_icon]',
+     'arrow-down'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][2][subform][field_oe_title][0][value]',
+      'Fact 3 title'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][2][subform][field_oe_subtitle][0][value]',
+      'Fact 3 subtitle'
+    );
+    $page->fillField(
+      'field_body[5][subform][field_oe_paragraphs][2][subform][field_oe_plain_text_long][0][value]',
+      'Fact 3 description'
+    );
+
     // Save node.
     $page->pressButton('Save');
 
@@ -212,6 +282,20 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     // Assert Content row.
     $assert_session->pageTextContains('Example title rich text 1');
     $assert_session->pageTextContains('Text description for rich text 1');
+
+    // Assert Facts and figures block.
+    $assert_session->pageTextContains('Example Facts and Figures');
+    $assert_session->pageTextContains('Read more');
+    $this->assertSession()->linkByHrefExists('http://read.more');
+    $assert_session->pageTextContains('Fact 1 title');
+    $assert_session->pageTextContains('Fact 1 subtitle');
+    $assert_session->pageTextContains('Fact 1 description');
+    $assert_session->pageTextContains('Fact 2 title');
+    $assert_session->pageTextContains('Fact 2 subtitle');
+    $assert_session->pageTextContains('Fact 2 description');
+    $assert_session->pageTextContains('Fact 3 title');
+    $assert_session->pageTextContains('Fact 3 subtitle');
+    $assert_session->pageTextContains('Fact 3 description');
   }
 
   /**

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -248,7 +248,7 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     // Add Description list paragraph.
     $page->pressButton('Add Description list');
     $page->selectFieldOption(
-      'field_body[6][subform][oe_bt_orientation]',
+      'field_body[6][subform][oe_w_orientation]',
       'horizontal'
     );
     $page->fillField(
@@ -315,7 +315,7 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     // Assert Facts and figures block.
     $assert_session->pageTextContains('Example Facts and Figures');
     $assert_session->pageTextContains('Read more');
-    $this->assertSession()->linkByHrefExists('http://read.more');
+    $assert_session->linkByHrefExists('http://read.more');
     $assert_session->pageTextContains('Fact 1 title');
     $assert_session->pageTextContains('Fact 1 subtitle');
     $assert_session->pageTextContains('Fact 1 description');


### PR DESCRIPTION
## OPENEUROPA-759

### Description

We need to:
* Enable paragraphs Facts and figures and Description list at Body field in OE Showcase Page content type.
* Provide of example of those two paragraphs at the Demo Page.
* Provide tests for those two paragraphs at the PageTest.php



