### PR TITLE
OEL-1369: Hide paragraph Contextual navigation and item paragraphs

### DIFF
--- a/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
+++ b/modules/oe_showcase_page/config/install/field.field.node.oe_showcase_page.field_body.yml
@@ -6,12 +6,10 @@ dependencies:
     - node.type.oe_showcase_page
     - paragraphs.paragraphs_type.contact_form
     - paragraphs.paragraphs_type.oe_accordion
-    - paragraphs.paragraphs_type.oe_accordion_item
     - paragraphs.paragraphs_type.oe_banner
     - paragraphs.paragraphs_type.oe_chart
     - paragraphs.paragraphs_type.oe_content_row
     - paragraphs.paragraphs_type.oe_links_block
-    - paragraphs.paragraphs_type.oe_list_item
     - paragraphs.paragraphs_type.oe_list_item_block
     - paragraphs.paragraphs_type.oe_map
     - paragraphs.paragraphs_type.oe_quote
@@ -36,20 +34,18 @@ settings:
   handler_settings:
     target_bundles:
       oe_accordion: oe_accordion
-      oe_accordion_item: oe_accordion_item
       oe_banner: oe_banner
-      oe_content_row: oe_content_row
-      contact_form: contact_form
-      oe_links_block: oe_links_block
-      oe_list_item: oe_list_item
       oe_chart: oe_chart
+      contact_form: contact_form
+      oe_content_row: oe_content_row
+      oe_links_block: oe_links_block
       oe_list_item_block: oe_list_item_block
+      oe_map: oe_map
       oe_quote: oe_quote
       oe_rich_text: oe_rich_text
+      oe_social_feed: oe_social_feed
       oe_text_feature_media: oe_text_feature_media
       oe_timeline: oe_timeline
-      oe_map: oe_map
-      oe_social_feed: oe_social_feed
     negate: 0
     target_bundles_drag_drop:
       contact_form:
@@ -60,7 +56,7 @@ settings:
         enabled: true
       oe_accordion_item:
         weight: 17
-        enabled: true
+        enabled: false
       oe_banner:
         weight: 18
         enabled: true
@@ -90,7 +86,7 @@ settings:
         enabled: true
       oe_list_item:
         weight: 28
-        enabled: true
+        enabled: false
       oe_list_item_block:
         weight: 29
         enabled: true

--- a/modules/oe_showcase_page/config/overrides/field.field.paragraph.oe_content_row.field_oe_paragraphs.yml
+++ b/modules/oe_showcase_page/config/overrides/field.field.paragraph.oe_content_row.field_oe_paragraphs.yml
@@ -1,0 +1,100 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_oe_paragraphs
+    - paragraphs.paragraphs_type.oe_accordion
+    - paragraphs.paragraphs_type.oe_content_row
+    - paragraphs.paragraphs_type.oe_links_block
+    - paragraphs.paragraphs_type.oe_list_item_block
+    - paragraphs.paragraphs_type.oe_quote
+    - paragraphs.paragraphs_type.oe_rich_text
+    - paragraphs.paragraphs_type.oe_social_media_follow
+  module:
+    - entity_reference_revisions
+id: paragraph.oe_content_row.field_oe_paragraphs
+field_name: field_oe_paragraphs
+entity_type: paragraph
+bundle: oe_content_row
+label: Paragraphs
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      oe_rich_text: oe_rich_text
+      oe_list_item_block: oe_list_item_block
+      oe_links_block: oe_links_block
+      oe_quote: oe_quote
+      oe_social_media_follow: oe_social_media_follow
+      oe_accordion: oe_accordion
+    negate: 0
+    target_bundles_drag_drop:
+      contact_form:
+        weight: 22
+        enabled: false
+      oe_accordion:
+        weight: -15
+        enabled: true
+      oe_accordion_item:
+        weight: -14
+        enabled: false
+      oe_banner:
+        weight: 25
+        enabled: false
+      oe_chart:
+        weight: 26
+        enabled: false
+      oe_content_row:
+        weight: -13
+        enabled: false
+      oe_contextual_navigation:
+        weight: -16
+        enabled: false
+      oe_description_list:
+        weight: 29
+        enabled: false
+      oe_document:
+        weight: 30
+        enabled: false
+      oe_fact:
+        weight: 31
+        enabled: false
+      oe_facts_figures:
+        weight: 32
+        enabled: false
+      oe_links_block:
+        weight: -20
+        enabled: true
+      oe_list_item:
+        weight: -12
+        enabled: false
+      oe_list_item_block:
+        weight: -21
+        enabled: true
+      oe_map:
+        weight: 36
+        enabled: false
+      oe_quote:
+        weight: -19
+        enabled: true
+      oe_rich_text:
+        weight: -22
+        enabled: true
+      oe_social_feed:
+        weight: 39
+        enabled: false
+      oe_social_media_follow:
+        weight: -17
+        enabled: true
+      oe_text_feature_media:
+        weight: 41
+        enabled: false
+      oe_timeline:
+        weight: 42
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/oe_showcase_page/oe_showcase_page.install
+++ b/modules/oe_showcase_page/oe_showcase_page.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for the OE Showcase Page module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\oe_bootstrap_theme\ConfigImporter;
+
+/**
+ * Implements hook_install().
+ *
+ * Imports configuration on module install.
+ */
+function oe_showcase_page_install(bool $is_syncing): void {
+  if ($is_syncing) {
+    return;
+  }
+
+  $configs = [
+    'field.field.paragraph.oe_content_row.field_oe_paragraphs',
+  ];
+
+  ConfigImporter::importMultiple('oe_showcase_page', '/config/overrides/', $configs);
+}

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -93,44 +93,36 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'field_body[3][variant]',
       'default'
     );
-
     $page->selectFieldOption(
       'field_body[3][subform][field_oe_list_item_block_layout]',
       'two_columns'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_title][0][value]',
       'List item block example'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_link][0][uri]',
       '<front>'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_title][0][value]',
       'Home Page'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_text_long][0][value]',
       'Listing item description'
     );
 
     $page->pressButton('Add Listing item');
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_link][0][uri]',
       'https://example1.com'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_title][0][value]',
       'Example 1 Page'
     );
-
     $page->fillField(
       'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_text_long][0][value]',
       'Listing item description for example 1'
@@ -155,12 +147,10 @@ class PageTest extends ShowcaseExistingSiteTestBase {
 
     // Add a Rich text paragraph at the Content row.
     $page->pressButton('Add Rich text');
-
     $page->fillField(
       'field_body[4][subform][field_oe_paragraphs][0][subform][field_oe_title][0][value]',
       'Example title rich text 1'
     );
-
     $page->fillField(
       'field_body[4][subform][field_oe_paragraphs][0][subform][field_oe_text_long][0][value]',
       'Text description for rich text 1'

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -12,13 +12,6 @@ use Drupal\Tests\oe_showcase\ExistingSite\ShowcaseExistingSiteTestBase;
 class PageTest extends ShowcaseExistingSiteTestBase {
 
   /**
-   * A user with permission to create 'oe_showcase_page' content.
-   *
-   * @var \Drupal\user\UserInterface
-   */
-  protected $user;
-
-  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
@@ -28,7 +21,7 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'create oe_showcase_page content',
     ];
 
-    $this->user = $this->createUser($permissions);
+    $this->drupalLogin($this->createUser($permissions));
   }
 
   /**
@@ -40,7 +33,6 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     $this->markEntityTypeForCleanup('paragraph');
 
     $assert_session = $this->assertSession();
-    $this->drupalLogin($this->user);
 
     // Create a Showcase Page node through the UI.
     $this->drupalGet('node/add/oe_showcase_page');

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -89,21 +89,54 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'T.S Eliot'
     );
 
-    // Add a listing item.
-    $page->pressButton('Add Listing item');
-    $page->fillField(
-      'field_body[3][subform][field_oe_link][0][uri]',
-      '<front>'
+    // Add a listing item block.
+    $page->pressButton('Add Listing item block');
+
+    $page->selectFieldOption(
+      'field_body[3][variant]',
+      'default'
+    );
+
+    $page->selectFieldOption(
+      'field_body[3][subform][field_oe_list_item_block_layout]',
+      'two_columns'
     );
 
     $page->fillField(
       'field_body[3][subform][field_oe_title][0][value]',
+      'List item block example'
+    );
+
+    $page->fillField(
+      'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_link][0][uri]',
+      '<front>'
+    );
+
+    $page->fillField(
+      'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_title][0][value]',
       'Home Page'
     );
 
     $page->fillField(
-      'field_body[3][subform][field_oe_text_long][0][value]',
+      'field_body[3][subform][field_oe_paragraphs][0][subform][field_oe_text_long][0][value]',
       'Listing item description'
+    );
+
+    $page->pressButton('Add Listing item');
+
+    $page->fillField(
+      'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_link][0][uri]',
+      'https://example1.com'
+    );
+
+    $page->fillField(
+      'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_title][0][value]',
+      'Example 1 Page'
+    );
+
+    $page->fillField(
+      'field_body[3][subform][field_oe_paragraphs][1][subform][field_oe_text_long][0][value]',
+      'Listing item description for example 1'
     );
 
     // Save node.
@@ -133,9 +166,12 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     $assert_session->pageTextContains('Banner 0 item title');
     $assert_session->pageTextContains('Banner 0 item Body');
 
-    // Assert Listing item.
-    $assert_session->pageTextContains('Home');
+    // Assert Listing item block.
+    $assert_session->pageTextContains('List item block example');
+    $assert_session->pageTextContains('Home Page');
     $assert_session->pageTextContains('Listing item description');
+    $assert_session->pageTextContains('Example 1 Page');
+    $assert_session->pageTextContains('Listing item description for example 1');
   }
 
 }

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -144,6 +144,36 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'Listing item description for example 1'
     );
 
+    // Add a Banner paragraph.
+    $page->pressButton('Add Content row');
+
+    $page->selectFieldOption(
+      'field_body[4][variant]',
+      'inpage_navigation'
+    );
+
+    // Check the list of paragraphs for Content row.
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-rich-text-add-more');
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-list-item-block-add-more');
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-links-block-add-more');
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-quote-add-more');
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-social-media-follow-add-more');
+    $assert_session->elementExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-accordion-add-more');
+    $assert_session->elementNotExists('css', '#field-body-4-subform-field-oe-paragraphs-oe-contextual-navigation-add-more');
+
+    // Add a Rich text paragraph at the Content row.
+    $page->pressButton('Add Rich text');
+
+    $page->fillField(
+      'field_body[4][subform][field_oe_paragraphs][0][subform][field_oe_title][0][value]',
+      'Example title rich text 1'
+    );
+
+    $page->fillField(
+      'field_body[4][subform][field_oe_paragraphs][0][subform][field_oe_text_long][0][value]',
+      'Text description for rich text 1'
+    );
+
     // Save node.
     $page->pressButton('Save');
 
@@ -177,6 +207,10 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     $assert_session->pageTextContains('Listing item description');
     $assert_session->pageTextContains('Example 1 Page');
     $assert_session->pageTextContains('Listing item description for example 1');
+
+    // Assert Content row.
+    $assert_session->pageTextContains('Example title rich text 1');
+    $assert_session->pageTextContains('Text description for rich text 1');
   }
 
 }

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -162,6 +162,7 @@ class PageTest extends ShowcaseExistingSiteTestBase {
       'field_body[4][variant]',
       'inpage_navigation'
     );
+    $page->pressButton('Change variant');
 
     // Add a Rich text paragraph at the Content row.
     $page->pressButton('Add Rich text');

--- a/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
+++ b/modules/oe_showcase_page/tests/src/ExistingSite/PageTest.php
@@ -52,6 +52,11 @@ class PageTest extends ShowcaseExistingSiteTestBase {
     // Set page description.
     $page->fillField('field_description[0][value]', 'Page demo description');
 
+    // Check the list of paragraphs disabled.
+    $assert_session->elementNotExists('css', '#field-body-oe-accordion-item-add-more');
+    $assert_session->elementNotExists('css', '#field-body-oe-list-item-add-more');
+    $assert_session->elementNotExists('css', '#field-body-oe-contextual-navigation-add-more');
+
     // Add Rich text paragraph.
     $page->pressButton('Add Rich text');
     $page->fillField(


### PR DESCRIPTION
## OPENEUROPA-[OEL-1369](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-1369)

### Description

At Page content type disable Accordion list item and List item.
At Content row paragraph type, disable Contextual navigation sub-paragraph.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

