### PR TITLE
OEL-1434: Update to alpha7 of oe_whitelabel.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "openeuropa/oe_paragraphs": "^1.13",
         "openeuropa/oe_starter_content": "1.0.0-beta1",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "1.0.0-alpha6"
+        "openeuropa/oe_whitelabel": "1.0.0-alpha7"
     },
     "require-dev": {
         "composer/installers": "~1.11",


### PR DESCRIPTION
## OPENEUROPA-[OEL-1434]

### Description

Update to alpha7 of oe_whitelabel because issue with filtering out bundles if no legacy fields present.