### PR TITLE
OEL-1416: Fixes after BCL 0.22.0 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "openeuropa/oe_paragraphs": "^1.13",
         "openeuropa/oe_starter_content": "1.0.0-beta1",
         "openeuropa/oe_webtools": "^1.14",
-        "openeuropa/oe_whitelabel": "1.0.0-alpha7"
+        "openeuropa/oe_whitelabel": "0.1.202204221923"
     },
     "require-dev": {
         "composer/installers": "~1.11",
@@ -90,14 +90,6 @@
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
         "installer-types": ["npm-asset", "bower-asset"],
-        "patches": {
-            "openeuropa/oe_bootstrap_theme": {
-                "latest": "https://github.com/openeuropa/oe_bootstrap_theme/compare/1.0.0-alpha8..1.x.diff"
-            },
-            "openeuropa/oe_whitelabel": {
-                "latest": "https://github.com/openeuropa/oe_whitelabel/compare/1.0.0-alpha7..1.x.diff"
-            }
-        },
         "artifacts": {
             "openeuropa/oe_bootstrap_theme": {
                 "dist": {

--- a/modules/oe_showcase_user_profile/templates/user--full.html.twig
+++ b/modules/oe_showcase_user_profile/templates/user--full.html.twig
@@ -6,7 +6,8 @@
 #}
 {% apply spaceless %}
 <article{{ attributes }}>
-  {# @todo Remove the 'px-0' once OEL-1226 is fixed. #}
+  {# Combine margin and padding for precise spacing. #}
+  {# @todo Remove the 'mx-n3', 'px-1' once OEL-1226 is fixed. #}
   {{ pattern('content_banner', {
     image: image,
     title: content.field_first_name|field_value|render ~ ' ' ~ content.field_last_name|field_value|render,
@@ -15,7 +16,7 @@
       content.group_professional_information.field_current_position|field_value,
     ],
     content: content.field_bio|field_value,
-    attributes: create_attribute().addClass('mb-4', 'px-0'),
+    attributes: create_attribute().addClass('mb-4', 'pb-3', 'mx-n3', 'px-1'),
   }) }}
   {{ _self.description_list_section('Personal information', content.group_personal_information ?? {}) }}
   {{ _self.description_list_section('Professional information', content.group_professional_information ?? {}) }}


### PR DESCRIPTION
The changes in composer.json need to be removed once the sibling PRs for OEL-1416 have been merged in oe_bootstrap_theme and oe_whitelabel.