### PR TITLE
OEL-1620: Revoke administer nodes permission to editor role.

### DIFF
--- a/config/install/user.role.editor.yml
+++ b/config/install/user.role.editor.yml
@@ -23,7 +23,6 @@ permissions:
   - 'access administration pages'
   - 'access content overview'
   - 'access toolbar'
-  - 'administer nodes'
   - 'create av_portal_photo media'
   - 'create document media'
   - 'create image media'

--- a/oe_showcase.post_update.php
+++ b/oe_showcase.post_update.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Drupal\block\Entity\Block;
 use Drupal\oe_bootstrap_theme\ConfigImporter;
+use Drupal\user\Entity\Role;
 
 /**
  * Set the updated regions of the oe_whitelabel navigation blocks.
@@ -66,4 +67,13 @@ function oe_showcase_post_update_00003(&$sandbox) {
     'user.role.manage_users',
   ];
   ConfigImporter::importMultiple('profile', 'oe_showcase', '/config/post_updates/00003_manage_users', $configs);
+}
+
+/**
+ * Revoke editor role's administer nodes permission.
+ */
+function oe_showcase_post_update_00004(&$sandbox) {
+  $role = Role::load('editor');
+  $role->revokePermission('administer nodes');
+  $role->save();
 }

--- a/tests/src/ExistingSite/ShowcaseExistingSiteCreateNewsTest.php
+++ b/tests/src/ExistingSite/ShowcaseExistingSiteCreateNewsTest.php
@@ -76,7 +76,6 @@ class ShowcaseExistingSiteCreateNewsTest extends ShowcaseExistingSiteTestBase {
     $page->fillField('Content', 'Example Content');
     $page->fillField('Introduction', 'Example Introduction');
     $page->fillField('Date', '2022-01-24');
-    $page->fillField('Time', '00:00:00');
     $media_name = $media_image->getName() . ' (' . $media_image->id() . ')';
     $page->fillField('Media item', $media_name);
     $page->pressButton('Save');


### PR DESCRIPTION
## OPENEUROPA-1620

### Description

Revoke administer nodes permission to editor role

### Change log

- Added:
- Changed: Editor role
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

