### PR TITLE
OEL-1651: Get the oe_starter_content development branch to test the published date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,6 +106,9 @@
             },
             "openeuropa/oe_list_pages": {
                 "Support Address field in country code processor": "https://patch-diff.githubusercontent.com/raw/openeuropa/oe_list_pages/pull/139.diff"
+            },
+            "openeuropa/oe_starter_content": {
+                "latest": "https://github.com/openeuropa/oe_starter_content/compare/1.0.0-beta1...1.x.diff"
             }
         },
         "artifacts": {

--- a/tests/src/ExistingSite/ShowcaseExistingSiteCreateNewsTest.php
+++ b/tests/src/ExistingSite/ShowcaseExistingSiteCreateNewsTest.php
@@ -75,6 +75,10 @@ class ShowcaseExistingSiteCreateNewsTest extends ShowcaseExistingSiteTestBase {
     $page->fillField('Title', 'Example title');
     $page->fillField('Content', 'Example Content');
     $page->fillField('Introduction', 'Example Introduction');
+    // Assert that publication date was filled with a default value.
+    $publication_date = $page->find('css', 'input[name="oe_publication_date[0][value][date]"]');
+    $this->assertMatchesRegularExpression("/\d+\-\d+\-\d+/", $publication_date->getValue());
+    // Set a custom publication date.
     $page->fillField('Date', '2022-01-24');
     $media_name = $media_image->getName() . ' (' . $media_image->id() . ')';
     $page->fillField('Media item', $media_name);


### PR DESCRIPTION
## OPENEUROPA-1651

### Description

Get the oe_starter_content development branch to test the published date. If published date is empty, then add the current date as published date.

### Change log

- Added:
- Changed: oe_starter_content has been updated
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

