### PR TITLE
OEL-1675: News title facet should search in all fields.

### DIFF
--- a/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_event__oe_sc_event_dates.yml
+++ b/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_event__oe_sc_event_dates.yml
@@ -3,27 +3,27 @@ status: true
 dependencies: {  }
 id: oelp_oe_sc_event__oe_sc_event_dates
 name: 'Event dates'
+url_alias: oelp_oe_sc_event__oe_sc_event_dates
 weight: 0
 min_count: 1
-url_alias: oelp_oe_sc_event__oe_sc_event_dates
-facet_source_id: 'list_facet_source:node:oe_sc_event'
+show_only_one_result: false
 field_identifier: oe_sc_event_dates
-query_operator: or
-hard_limit: 0
-exclude: false
-use_hierarchy: false
-keep_hierarchy_parents_active: false
-expand_hierarchy: false
-enable_parent_when_child_gets_disabled: true
+facet_source_id: 'list_facet_source:node:oe_sc_event'
 widget:
   type: oe_list_pages_date
   config:
     date_type: date
-empty_behavior:
-  behavior: none
+query_operator: or
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+hard_limit: 0
+exclude: false
 only_visible_when_facet_source_is_visible: true
-show_only_one_result: false
-show_title: false
 processor_configs:
   active_widget_order:
     processor_id: active_widget_order
@@ -49,3 +49,6 @@ processor_configs:
       pre_query: 50
       build: 15
     settings: {  }
+empty_behavior:
+  behavior: none
+show_title: false

--- a/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_event__title.yml
+++ b/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_event__title.yml
@@ -13,12 +13,15 @@ hard_limit: 0
 exclude: false
 use_hierarchy: false
 keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 widget:
   type: oe_list_pages_fulltext
   config:
-    fulltext_all_fields: true
+    fulltext_all_fields: false
 empty_behavior:
   behavior: none
 only_visible_when_facet_source_is_visible: true
@@ -43,6 +46,11 @@ processor_configs:
       sort: 40
     settings:
       sort: ASC
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
   url_processor_handler:
     processor_id: url_processor_handler
     weights:

--- a/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__oe_publication_date.yml
+++ b/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__oe_publication_date.yml
@@ -16,6 +16,9 @@ widget:
 query_operator: or
 use_hierarchy: false
 keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
 expand_hierarchy: false
 enable_parent_when_child_gets_disabled: true
 hard_limit: 0

--- a/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__title.yml
+++ b/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__title.yml
@@ -2,25 +2,31 @@ langcode: en
 status: true
 dependencies: {  }
 id: oelp_oe_sc_news__title
-name: Title
-url_alias: oelp_oe_sc_news__title
+name: Keyword
 weight: 0
 min_count: 1
-show_only_one_result: false
-field_identifier: title
+url_alias: oelp_oe_sc_news__title
 facet_source_id: 'list_facet_source:node:oe_sc_news'
+field_identifier: title
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
 widget:
   type: oe_list_pages_fulltext
   config:
     fulltext_all_fields: true
-query_operator: or
-use_hierarchy: false
-keep_hierarchy_parents_active: false
-expand_hierarchy: false
-enable_parent_when_child_gets_disabled: true
-hard_limit: 0
-exclude: false
+empty_behavior:
+  behavior: none
 only_visible_when_facet_source_is_visible: true
+show_only_one_result: false
+show_title: false
 processor_configs:
   active_widget_order:
     processor_id: active_widget_order
@@ -46,6 +52,3 @@ processor_configs:
       pre_query: 50
       build: 15
     settings: {  }
-empty_behavior:
-  behavior: none
-show_title: false

--- a/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__title.yml
+++ b/modules/oe_showcase_list_pages/config/install/facets.facet.oelp_oe_sc_news__title.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: oelp_oe_sc_news__title
-name: Keyword
+name: Keywords
 weight: 0
 min_count: 1
 url_alias: oelp_oe_sc_news__title

--- a/modules/oe_showcase_list_pages/config/install/search_api.index.oe_list_pages_index.yml
+++ b/modules/oe_showcase_list_pages/config/install/search_api.index.oe_list_pages_index.yml
@@ -3,9 +3,9 @@ status: true
 dependencies:
   config:
     - field.storage.node.body
+    - field.storage.node.oe_publication_date
     - field.storage.node.oe_sc_event_dates
     - field.storage.node.oe_summary
-    - field.storage.node.oe_publication_date
     - search_api.server.oe_list_pages_search_server
   module:
     - node
@@ -83,6 +83,8 @@ processor_settings:
       preprocess_query: -20
     all_fields: false
     fields:
+      - body
+      - oe_summary
       - title
   language_with_fallback: {  }
   rendered_item: {  }

--- a/modules/oe_showcase_list_pages/config/install/search_api.index.oe_list_pages_index.yml
+++ b/modules/oe_showcase_list_pages/config/install/search_api.index.oe_list_pages_index.yml
@@ -2,7 +2,9 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.body
     - field.storage.node.oe_sc_event_dates
+    - field.storage.node.oe_summary
     - field.storage.node.oe_publication_date
     - search_api.server.oe_list_pages_search_server
   module:
@@ -13,6 +15,14 @@ name: 'List pages index'
 description: ''
 read_only: false
 field_settings:
+  body:
+    label: Content
+    datasource_id: 'entity:node'
+    property_path: body
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.body
   oe_publication_date:
     label: 'Publication date'
     datasource_id: 'entity:node'
@@ -29,6 +39,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.oe_sc_event_dates
+  oe_summary:
+    label: Introduction
+    datasource_id: 'entity:node'
+    property_path: oe_summary
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.oe_summary
   title:
     label: Title
     datasource_id: 'entity:node'

--- a/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
+++ b/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
@@ -170,18 +170,12 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
     $this->assertSearchResults([
       'News number 6',
     ]);
-    $title_input->setValue('NUMBER this');
+    // @todo Remove "7" once we have a default order.
+    $title_input->setValue('NUMBER 7 this');
     $search_button->click();
-    $this->assertSearchResultsTitle('News list page', 8);
+    $this->assertSearchResultsTitle('News list page', 1);
     $this->assertSearchResults([
-      'News number 10',
-      'News number 8',
-      'News number 6',
-      'News number 4',
-      'News number 11',
-      'News number 9',
       'News number 7',
-      'News number 5',
     ]);
 
     // Assert only News nodes are part of the result.

--- a/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
+++ b/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
@@ -61,6 +61,7 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
         'title' => 'Event number ' . $i,
         'type' => 'oe_sc_event',
         'body' => 'This is an Event content number ' . $i,
+        'oe_summary' => 'This is an Event introduction number ' . $i,
         'language' => 'en',
         'status' => NodeInterface::PUBLISHED,
         'oe_sc_event_dates' => [
@@ -239,6 +240,14 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
 
     // Assert only Event nodes are part of the result.
     $title_input->setValue('News number 1');
+    $search_button->click();
+    $this->assertSearchResultsTitle('Event list page', 0);
+
+    // Assert Event title filters only by title.
+    $title_input->setValue('This is an Event content number 10');
+    $search_button->click();
+    $this->assertSearchResultsTitle('Event list page', 0);
+    $title_input->setValue('This is an Event introduction number 10');
     $search_button->click();
     $this->assertSearchResultsTitle('Event list page', 0);
   }

--- a/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
+++ b/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
@@ -46,6 +46,7 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
         'title' => 'News number ' . $i,
         'type' => 'oe_sc_news',
         'body' => 'This is a News content number ' . $i,
+        'oe_summary' => 'This is a News introduction number ' . $i,
         'language' => 'en',
         'status' => NodeInterface::PUBLISHED,
         'oe_publication_date' => sprintf('2022-04-%02d', $i + 1),
@@ -91,6 +92,7 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
     $this->drupalGet('node/' . $node->id());
 
     // Assert that only News items are displayed.
+    $this->assertSearchResultsTitle('News list page', 12);
     $this->assertSearchResults([
       'News number 0',
       'News number 1',
@@ -112,7 +114,7 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
 
     // Assert that the filter form for News exists.
     $filter_form = $assert_session->elementExists('css', '#oe-list-pages-facets-form');
-    $title_input = $filter_form->findField('Title');
+    $title_input = $filter_form->findField('Keyword');
     $publication_date_input = $filter_form->findField('Publication date');
     $search_button = $filter_form->find('css', '#edit-submit');
     $this->assertNotNull($search_button);
@@ -142,6 +144,22 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
     $this->assertSearchResultsTitle('News list page', 1);
     $this->assertSearchResults([
       'News number 8',
+    ]);
+
+    // Filter the News results by content.
+    $title_input->setValue('This is a News content number 10');
+    $search_button->click();
+    $this->assertSearchResultsTitle('News list page', 1);
+    $this->assertSearchResults([
+      'News number 10',
+    ]);
+
+    // Filter the News results by introduction.
+    $title_input->setValue('This is a News introduction number 11');
+    $search_button->click();
+    $this->assertSearchResultsTitle('News list page', 1);
+    $this->assertSearchResults([
+      'News number 11',
     ]);
 
     // Assert only News nodes are part of the result.

--- a/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
+++ b/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
@@ -163,6 +163,27 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
       'News number 11',
     ]);
 
+    // Filter by a mix of introduction and content in shuffled order.
+    $title_input->setValue('6 content number introduction');
+    $search_button->click();
+    $this->assertSearchResultsTitle('News list page', 1);
+    $this->assertSearchResults([
+      'News number 6',
+    ]);
+    $title_input->setValue('NUMBER this');
+    $search_button->click();
+    $this->assertSearchResultsTitle('News list page', 8);
+    $this->assertSearchResults([
+      'News number 10',
+      'News number 8',
+      'News number 6',
+      'News number 4',
+      'News number 11',
+      'News number 9',
+      'News number 7',
+      'News number 5',
+    ]);
+
     // Assert only News nodes are part of the result.
     $title_input->setValue('Event example');
     $search_button->click();

--- a/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
+++ b/modules/oe_showcase_list_pages/tests/src/ExistingSite/ListPagesTest.php
@@ -115,7 +115,7 @@ class ListPagesTest extends ShowcaseExistingSiteTestBase {
 
     // Assert that the filter form for News exists.
     $filter_form = $assert_session->elementExists('css', '#oe-list-pages-facets-form');
-    $title_input = $filter_form->findField('Keyword');
+    $title_input = $filter_form->findField('Keywords');
     $publication_date_input = $filter_form->findField('Publication date');
     $search_button = $filter_form->find('css', '#edit-submit');
     $this->assertNotNull($search_button);


### PR DESCRIPTION
## OEL-1675

### Description

Requirements ask for it to be search in title, synopsis, and content.

The other way around for event, now that we add new fulltext fields, we need to make sure that it does not break the Event name search by searching in these new fields.

### Change log

- Added: fields body and oe_summary to the index
- Changed:
  - news title facet - renamed label
  - event title facet - do not search in all fulltest fields, only title
  - listed the new fields in the lowercase processors
  - adapted the tests


