### PR TITLE
OEL-1638: Bring changes from oe_whitelabel to fix warning in search page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,9 @@
             },
             "openeuropa/oe_starter_content": {
                 "OEL-1651: Published date prefilled with current date": "https://patch-diff.githubusercontent.com/raw/openeuropa/oe_starter_content/pull/9.diff"
+            },
+            "openeuropa/oe_whitelabel": {
+                "OEL-1638: Avoid warning": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.202206241900...OEL-1638.diff"
             }
         },
         "artifacts": {


### PR DESCRIPTION
## OPENEUROPA-1638

### Description

Fix warning in search page. 

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

