### PR TITLE
OEL-3058: Fix breaking corporate blocks update path.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "openeuropa/oe_contact_forms": "^1.5",
         "openeuropa/oe_content": "^3.0.0-alpha11",
         "openeuropa/oe_content_extra": "^1.1.0",
-        "openeuropa/oe_corporate_blocks": "^4.13",
+        "openeuropa/oe_corporate_blocks": "^4.19",
         "openeuropa/oe_corporate_countries": "^2.0.0-alpha8",
         "openeuropa/oe_dashboard_agent": "^1.0.0",
         "openeuropa/oe_list_pages": "^1.0",
@@ -118,6 +118,9 @@
             },
             "drupal/facets_form": {
                 "Form facets cache dependency @see https://www.drupal.org/project/facets_form/issues/3400844": "https://www.drupal.org/files/issues/2023-11-13/form-facets-cache-dependency-3400844-41.patch"
+            },
+            "openeuropa/oe_corporate_blocks": {
+                "Check strings before deletion": "https://github.com/openeuropa/oe_corporate_blocks/compare/4.x...OEL-3058.diff"
             }
         },
         "patchLevel": {

--- a/composer.json
+++ b/composer.json
@@ -123,6 +123,13 @@
                 "Check strings before deletion": "https://github.com/openeuropa/oe_corporate_blocks/compare/4.x...OEL-3058.diff"
             }
         },
+        "patches-ignore": {
+            "openeuropa/oe_contact_forms": {
+                "drupal/sparql_entity_storage": {
+                    "https://www.drupal.org/project/sparql_entity_storage/issues/3409679": "https://www.drupal.org/files/issues/2024-01-15/3409679.patch"
+                }
+            }
+        },
         "patchLevel": {
             "drupal/core": "-p2"
         },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22e835bdb819653a908af2d75cbf1c3b",
+    "content-hash": "becb546b21b7944b8708850b6c8f231f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7067,16 +7067,16 @@
         },
         {
             "name": "openeuropa/oe_corporate_blocks",
-            "version": "4.18.0",
+            "version": "4.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openeuropa/oe_corporate_blocks.git",
-                "reference": "dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e"
+                "reference": "4d8418b5c04973ff5ff9979f95d35cfa196d85fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openeuropa/oe_corporate_blocks/zipball/dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e",
-                "reference": "dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e",
+                "url": "https://api.github.com/repos/openeuropa/oe_corporate_blocks/zipball/4d8418b5c04973ff5ff9979f95d35cfa196d85fa",
+                "reference": "4d8418b5c04973ff5ff9979f95d35cfa196d85fa",
                 "shasum": ""
             },
             "require": {
@@ -7138,9 +7138,9 @@
             "description": "OpenEuropa Corporate Blocks.",
             "support": {
                 "issues": "https://github.com/openeuropa/oe_corporate_blocks/issues",
-                "source": "https://github.com/openeuropa/oe_corporate_blocks/tree/4.18.0"
+                "source": "https://github.com/openeuropa/oe_corporate_blocks/tree/4.19.1"
             },
-            "time": "2024-04-16T06:46:34+00:00"
+            "time": "2024-06-13T10:49:20+00:00"
         },
         {
             "name": "openeuropa/oe_corporate_countries",
@@ -20537,5 +20537,5 @@
         "php": ">=8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## OEL-3058

### Description

Websites other than ewpp may not have the strings, so when the local storage tries to fetch them the result will be null.

@see https://github.com/openeuropa/oe_corporate_blocks/pull/159

### Change log

- Added: oe_corporate_blocks patch, oe_contact_forms patch ignore

