### PR TITLE
OEL-3158: Reposition eu-footer items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,11 +126,6 @@
                 "drupal/field_group": {
                     "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"
                 }
-            },
-            "openeuropa/oe_content": {
-                "drupal/field_group": {
-                    "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"
-                }
             }
         },
         "patchLevel": {

--- a/composer.json
+++ b/composer.json
@@ -116,9 +116,17 @@
             },
             "drupal/entity_browser": {
                 "Permissions should declare their dependency on entity browser config entity": "https://www.drupal.org/files/issues/2023-08-16/3381497-4.patch"
+            },
+            "openeuropa/oe_whitelabel": {
+                "Move the Legal section to the top right position in the EU footer": "https://github.com/openeuropa/oe_whitelabel/compare/1.x...contribution/UCPKN-3181.diff"
             }
         },
         "patches-ignore": {
+            "openeuropa/oe_content": {
+                "drupal/field_group": {
+                    "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"
+                }
+            },
             "openeuropa/oe_content": {
                 "drupal/field_group": {
                     "https://www.drupal.org/project/field_group/issues/2787179": "https://www.drupal.org/files/issues/2023-04-07/2787179-highlight-html5-validation-85.patch"

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
                 "Permissions should declare their dependency on entity browser config entity": "https://www.drupal.org/files/issues/2023-08-16/3381497-4.patch"
             },
             "openeuropa/oe_whitelabel": {
-                "Move the Legal section to the top right position in the EU footer": "https://github.com/openeuropa/oe_whitelabel/compare/1.x...contribution/UCPKN-3181.diff"
+                "1.x": "https://github.com/openeuropa/oe_whitelabel/compare/0.1.20240806928...1.x.diff"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77b4357feb2e25306ae501fe6a889149",
+    "content-hash": "0f11bfd01e8739d56bf534bc9fa7eef0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1828,6 +1828,10 @@
                     "homepage": "https://www.drupal.org/user/655282"
                 },
                 {
+                    "name": "JeremySkinner",
+                    "homepage": "https://www.drupal.org/user/3564170"
+                },
+                {
                     "name": "yanniboi",
                     "homepage": "https://www.drupal.org/user/1837556"
                 }
@@ -2166,12 +2170,20 @@
                     "homepage": "https://www.drupal.org/user/3094661"
                 },
                 {
+                    "name": "rakesh.gectcr",
+                    "homepage": "https://www.drupal.org/user/1177822"
+                },
+                {
                     "name": "renatog",
                     "homepage": "https://www.drupal.org/user/3326031"
                 },
                 {
                     "name": "sonemonu",
                     "homepage": "https://www.drupal.org/user/1667988"
+                },
+                {
+                    "name": "spuky",
+                    "homepage": "https://www.drupal.org/user/209353"
                 },
                 {
                     "name": "tatarbj",
@@ -3769,10 +3781,6 @@
                 {
                     "name": "Robert Castelo",
                     "homepage": "https://www.drupal.org/user/3555"
-                },
-                {
-                    "name": "vegantriathlete",
-                    "homepage": "https://www.drupal.org/user/491720"
                 }
             ],
             "description": "Display Terms and Conditions statement on the registration page.",
@@ -20526,5 +20534,5 @@
         "php": ">=8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -7079,16 +7079,16 @@
         },
         {
             "name": "openeuropa/oe_corporate_blocks",
-            "version": "4.18.0",
+            "version": "4.19.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openeuropa/oe_corporate_blocks.git",
-                "reference": "dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e"
+                "reference": "f365bbd345541325b5a28b6e3df36045ea1e1d20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/openeuropa/oe_corporate_blocks/zipball/dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e",
-                "reference": "dfba0e9418d8bae855ca50cad3bc1eeb3ec0dc3e",
+                "url": "https://api.github.com/repos/openeuropa/oe_corporate_blocks/zipball/f365bbd345541325b5a28b6e3df36045ea1e1d20",
+                "reference": "f365bbd345541325b5a28b6e3df36045ea1e1d20",
                 "shasum": ""
             },
             "require": {
@@ -7150,9 +7150,9 @@
             "description": "OpenEuropa Corporate Blocks.",
             "support": {
                 "issues": "https://github.com/openeuropa/oe_corporate_blocks/issues",
-                "source": "https://github.com/openeuropa/oe_corporate_blocks/tree/4.18.0"
+                "source": "https://github.com/openeuropa/oe_corporate_blocks/tree/4.19.2"
             },
-            "time": "2024-04-16T06:46:34+00:00"
+            "time": "2024-06-24T14:53:49+00:00"
         },
         {
             "name": "openeuropa/oe_corporate_countries",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f890fe682887c85097fd12dba3332ccf",
+    "content-hash": "77b4357feb2e25306ae501fe6a889149",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## OEL-3158

### Description

Reposition eu-footer items with openeuropa/oe_corporate_blocks version 4.19.0 and above

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:


